### PR TITLE
Add power operation to calculator functionality

### DIFF
--- a/api/controller.js
+++ b/api/controller.js
@@ -16,6 +16,7 @@ exports.calculate = function(req, res) {
     'subtract': function(a, b) { return a - b },
     'multiply': function(a, b) { return a * b },
     'divide':   function(a, b) { return a / b },
+    'power':   function(a, b) { return Math.pow(a, b) },
   };
 
   if (!req.query.operation) {


### PR DESCRIPTION
This pull request adds a new feature to the `calculate` function in `api/controller.js`, enabling support for exponentiation (power) operations.

* [`api/controller.js`](diffhunk://#diff-401952c3eed6d886c8b542cd80766fc87baba4f1561c1c0373363350053a12caR19): Added a new operation, `'power'`, to the `operations` object, which calculates `a` raised to the power of `b` using `Math.pow(a, b)`.