### PR TITLE
Add Express server setup with Docker support and initial configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,14 @@ services:
       - 8000:8000
     volumes:
       - ./python-server/src:/app/src
+
+  express-server:
+    build:
+      context: ./express-server
+      dockerfile: Dockerfile
+    ports:
+      - 8001:8001
+    volumes:
+      - ./express-server/src:/app/src
+      - ./express-server/yarn.lock:/app/yarn.lock
+      - ./express-server/package.json:/app/package.json

--- a/express-server/Dockerfile
+++ b/express-server/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:14
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install
+
+EXPOSE 8001
+
+CMD ["yarn", "start"]

--- a/express-server/README.md
+++ b/express-server/README.md
@@ -1,0 +1,51 @@
+# Express Server
+
+This project is a simple Express server that listens on port 8001. It is set up to use Nodemon for automatic code reloading during development.
+
+## Getting Started
+
+To get started with this project, follow the steps below:
+
+### Prerequisites
+
+Make sure you have [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/) installed on your machine.
+
+### Installation
+
+1. Clone the repository:
+   ```
+   git clone <repository-url>
+   cd express-server
+   ```
+
+2. Install the dependencies:
+   ```
+   yarn install
+   ```
+
+### Running the Server
+
+To start the server with automatic reloading, use the following command:
+```
+yarn start
+```
+
+The server will be running on [http://localhost:8001](http://localhost:8001).
+
+### Docker
+
+To build and run the server using Docker, use the following commands:
+
+1. Build the Docker image:
+   ```
+   docker build -t express-server .
+   ```
+
+2. Run the Docker container:
+   ```
+   docker run -p 8001:8001 express-server
+   ```
+
+### License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/express-server/package.json
+++ b/express-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "express-server",
+  "version": "1.0.0",
+  "description": "A simple Express server",
+  "main": "src/app.js",
+  "scripts": {
+    "start": "nodemon src/app.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.7"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/express-server/src/app.js
+++ b/express-server/src/app.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const app = express();
+
+const PORT = 8001;
+
+app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
This pull request introduces a new `express-server` service to the project, alongside its Docker setup and basic implementation. The most important changes include adding the service to `docker-compose.yml`, creating a Dockerfile for the server, implementing the server's functionality, and providing documentation and configuration files.

### New `express-server` Service:

* **`docker-compose.yml`:** Added a new `express-server` service with its build context, ports, and volume mappings for the source code and configuration files.
* **`express-server/Dockerfile`:** Created a Dockerfile to set up the `express-server` using Node.js 14, installing dependencies via Yarn, and exposing port 8001.

### Server Implementation:

* **`express-server/src/app.js`:** Implemented a basic Express server that listens on port 8001 and logs a message when started.
* **`express-server/package.json`:** Added configuration for the server, including dependencies (`express`) and development tools (`nodemon`) for automatic reloading.

### Documentation:

* **`express-server/README.md`:** Added comprehensive documentation for setting up, running, and using the `express-server`, including Docker instructions and prerequisites.